### PR TITLE
Allow ogg mimetype to be uploaded

### DIFF
--- a/src/handlers/upload.ts
+++ b/src/handlers/upload.ts
@@ -29,7 +29,8 @@ const isValidFile = async (fileType?: FileTypeResult) => {
 
   return (
     validExtensions.includes(fileType.ext) ||
-    fileType.mime === 'audio/mpeg'
+    fileType.mime === 'audio/mpeg' || 
+    fileType.mime === 'audio/ogg'
   );
 };
 


### PR DESCRIPTION
Ogg extension was allowed but the 'audio/ogg' mimetype was not, so upload failed.