### PR TITLE
fix: Don't sort audios before sending to client

### DIFF
--- a/src/handlers/sounds.ts
+++ b/src/handlers/sounds.ts
@@ -8,7 +8,7 @@ export const soundsHandler = async (
 ) => {
   try {
     res.json(
-      db.sounds.list().sort((a, b) => a.name.localeCompare(b.name))
+      db.sounds.list()
     );
   } catch (err) {
     next(err);

--- a/src/handlers/sounds.ts
+++ b/src/handlers/sounds.ts
@@ -7,9 +7,7 @@ export const soundsHandler = async (
   next: NextFunction
 ) => {
   try {
-    res.json(
-      db.sounds.list()
-    );
+    res.json(db.sounds.list());
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
The client can sort the sounds by alphabetical order later if needed but the client can't know the original order if we sort it on the server.